### PR TITLE
Add /var/log/journal/ dir

### DIFF
--- a/pkg/generator/templates/cloud-init/suse-chost.template
+++ b/pkg/generator/templates/cloud-init/suse-chost.template
@@ -39,8 +39,10 @@ runcmd:
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
+- mkdir -p /var/log/journal/
 - systemctl daemon-reload
-- systemctl enable docker && systemctl restart docker
+- systemctl enable docker && systemctl restart docker 
+- systemctl enable systemd-journald && systemctl restart systemd-journald
 {{ end -}}
 - systemctl daemon-reload
 {{ range $_, $unit := .Units -}}

--- a/pkg/generator/templates/script/suse-chost.template
+++ b/pkg/generator/templates/script/suse-chost.template
@@ -58,8 +58,10 @@ until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sle
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
+mkdir -p /var/log/journal/
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
+systemctl enable systemd-journald && systemctl restart systemd-journald
 {{ end -}}
 systemctl daemon-reload
 {{ range $_, $unit := .Units -}}

--- a/pkg/generator/testfiles/cloud-init/cloud-init
+++ b/pkg/generator/testfiles/cloud-init/cloud-init
@@ -24,8 +24,10 @@ runcmd:
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
+- mkdir -p /var/log/journal/
 - systemctl daemon-reload
-- systemctl enable docker && systemctl restart docker
+- systemctl enable docker && systemctl restart docker 
+- systemctl enable systemd-journald && systemctl restart systemd-journald
 - systemctl daemon-reload
 
 - systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -33,8 +33,10 @@ until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sle
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
+mkdir -p /var/log/journal/
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
+systemctl enable systemd-journald && systemctl restart systemd-journald
 systemctl daemon-reload
 
 systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/script/cloud-init-memoryone-chost-bootstrap
+++ b/pkg/generator/testfiles/script/cloud-init-memoryone-chost-bootstrap
@@ -42,8 +42,10 @@ until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sle
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
+mkdir -p /var/log/journal/
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
+systemctl enable systemd-journald && systemctl restart systemd-journald
 systemctl daemon-reload
 
 systemctl enable 'docker.service' && systemctl restart 'docker.service'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:
Logging integration tests fail on `suse` nodes because of missing directory `/var/log/journal`
The directory in which the journal logs are kept is determined by the  `Journal. Storage` property in the `/etc/systemd/journald.conf` file.
Currently is is missing which means that it uses its default value `auto `.
With this value the systemd acts in the following way: If the directory `/var/log/journal` exists, then push the logs there,
otherwise push the logs to `/run/log/journal`.

This PR creates the directory and fixes the problem.
Used docs: https://www.freedesktop.org/software/systemd/man/journald.conf.html#Options

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
