### PR TITLE
Avoid unnecessary restart of systemd services

### DIFF
--- a/pkg/generator/templates/cloud-init.suse-chost.template
+++ b/pkg/generator/templates/cloud-init.suse-chost.template
@@ -43,10 +43,5 @@ runcmd:
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 - systemctl daemon-reload
 - systemctl enable docker && systemctl restart docker
-{{ end -}}
-- systemctl daemon-reload
-{{ range $_, $unit := .Units -}}
-{{- if or (ne $unit.Name "cloud-config-downloader.service") ($.Bootstrap) }}
-- systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
-{{ end -}}
+- systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 {{ end -}}

--- a/pkg/generator/templates/script.suse-chost.template
+++ b/pkg/generator/templates/script.suse-chost.template
@@ -69,12 +69,7 @@ ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
-{{ end -}}
-systemctl daemon-reload
-{{ range $_, $unit := .Units -}}
-{{- if or (ne $unit.Name "cloud-config-downloader.service") ($.Bootstrap) }}
-systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
-{{ end -}}
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 {{ end -}}
 {{- if and (eq .Type "memoryone-chost") .Bootstrap }}
 --==BOUNDARY==

--- a/pkg/generator/testfiles/cloudinit/cloud-init
+++ b/pkg/generator/testfiles/cloudinit/cloud-init
@@ -29,6 +29,4 @@ runcmd:
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 - systemctl daemon-reload
 - systemctl enable docker && systemctl restart docker
-- systemctl daemon-reload
-
-- systemctl enable 'docker.service' && systemctl restart 'docker.service'
+- systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -39,7 +39,5 @@ ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
-systemctl daemon-reload
-
-systemctl enable 'docker.service' && systemctl restart 'docker.service'
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 

--- a/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
@@ -44,10 +44,6 @@ ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
-systemctl daemon-reload
-
-systemctl enable 'docker.service' && systemctl restart 'docker.service'
-
-systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 
 --==BOUNDARY==

--- a/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
@@ -22,7 +22,4 @@ then
   grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
   wicked ifreload eth0
 fi
-systemctl daemon-reload
-
-systemctl enable 'docker.service' && systemctl restart 'docker.service'
 


### PR DESCRIPTION
/os suse-chost
/area os
/kind cleanup enhancement

Avoid unnecessary restart of systemd services.
The service restarts are executed by the script maintained in Gardener here https://github.com/gardener/gardener/blob/17de192a8956c28f76a6967daf865592cd3be1f5/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh#L162-L166

similar to https://github.com/gardener/gardener-extension-os-gardenlinux/pull/41


```other operator
This extension is no longer restarting the systemd services from the original OperatingSystemConfig units.
```

