### PR TITLE
Mitigate issue in systemd-hostnamed braking hostnamectl and preventing kubelet to restart

### DIFF
--- a/pkg/generator/templates/script.suse-chost.template
+++ b/pkg/generator/templates/script.suse-chost.template
@@ -62,6 +62,19 @@ then
   grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
   wicked ifreload eth0
 fi
+
+# mitigate https://github.com/systemd/systemd/issues/7082
+# ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
+SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
+if [[ $SYSMTED_VERSION -lt 236 ]]; then
+  mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
+  cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
+[Service]
+ProtectSystem=full
+EOF
+  systemctl daemon-reload
+fi
+
 {{ if .Bootstrap -}}
 until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -33,6 +33,19 @@ then
   grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
   wicked ifreload eth0
 fi
+
+# mitigate https://github.com/systemd/systemd/issues/7082
+# ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
+SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
+if [[ $SYSMTED_VERSION -lt 236 ]]; then
+  mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
+  cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
+[Service]
+ProtectSystem=full
+EOF
+  systemctl daemon-reload
+fi
+
 until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip

--- a/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
@@ -38,6 +38,19 @@ then
   grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
   wicked ifreload eth0
 fi
+
+# mitigate https://github.com/systemd/systemd/issues/7082
+# ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
+SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
+if [[ $SYSMTED_VERSION -lt 236 ]]; then
+  mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
+  cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
+[Service]
+ProtectSystem=full
+EOF
+  systemctl daemon-reload
+fi
+
 until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip

--- a/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
@@ -23,3 +23,16 @@ then
   wicked ifreload eth0
 fi
 
+# mitigate https://github.com/systemd/systemd/issues/7082
+# ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
+SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
+if [[ $SYSMTED_VERSION -lt 236 ]]; then
+  mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
+  cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
+[Service]
+ProtectSystem=full
+EOF
+  systemctl daemon-reload
+fi
+
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:
Mitigate issue in systemd-hostnamed braking hostnamectl and preventing kubelet to restart
Some versions of SuSE CHost are still affected by https://github.com/systemd/systemd/issues/7082.
The mitigation is suggested here https://github.com/coreos/bugs/issues/2193#issuecomment-337767555

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other use
An issue with old version of systemd preventing the `hostnamectl set-hostname` command to succeed and let kubelet start successfully has been mitigated.
```
