### PR TITLE
Improve version constraint for systemd-hostnamed mitigation

### DIFF
--- a/pkg/generator/templates/script.suse-chost.template
+++ b/pkg/generator/templates/script.suse-chost.template
@@ -66,7 +66,10 @@ fi
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
 SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
-if [[ $SYSMTED_VERSION -lt 236 ]]; then
+SUSE_VARIANT_VERSION=$(grep -oP '(?<=^VARIANT_VERSION=).+' /etc/os-release | tr -d '"')
+SUSE_SP_ID=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d '.' -f 2)
+
+if [[ $SYSMTED_VERSION -lt 236 && -n $SUSE_SP_ID && $SUSE_SP_ID -lt 3 && -n $SUSE_VARIANT_VERSION && $SUSE_VARIANT_VERSION -lt 20210722 ]]; then
   mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
   cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
 [Service]

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -37,7 +37,10 @@ fi
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
 SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
-if [[ $SYSMTED_VERSION -lt 236 ]]; then
+SUSE_VARIANT_VERSION=$(grep -oP '(?<=^VARIANT_VERSION=).+' /etc/os-release | tr -d '"')
+SUSE_SP_ID=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d '.' -f 2)
+
+if [[ $SYSMTED_VERSION -lt 236 && -n $SUSE_SP_ID && $SUSE_SP_ID -lt 3 && -n $SUSE_VARIANT_VERSION && $SUSE_VARIANT_VERSION -lt 20210722 ]]; then
   mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
   cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
 [Service]

--- a/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-bootstrap
@@ -42,7 +42,10 @@ fi
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
 SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
-if [[ $SYSMTED_VERSION -lt 236 ]]; then
+SUSE_VARIANT_VERSION=$(grep -oP '(?<=^VARIANT_VERSION=).+' /etc/os-release | tr -d '"')
+SUSE_SP_ID=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d '.' -f 2)
+
+if [[ $SYSMTED_VERSION -lt 236 && -n $SUSE_SP_ID && $SUSE_SP_ID -lt 3 && -n $SUSE_VARIANT_VERSION && $SUSE_VARIANT_VERSION -lt 20210722 ]]; then
   mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
   cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
 [Service]

--- a/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
+++ b/pkg/generator/testfiles/script/script.memoryone-chost-reconcile
@@ -26,7 +26,10 @@ fi
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
 SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
-if [[ $SYSMTED_VERSION -lt 236 ]]; then
+SUSE_VARIANT_VERSION=$(grep -oP '(?<=^VARIANT_VERSION=).+' /etc/os-release | tr -d '"')
+SUSE_SP_ID=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d '.' -f 2)
+
+if [[ $SYSMTED_VERSION -lt 236 && -n $SUSE_SP_ID && $SUSE_SP_ID -lt 3 && -n $SUSE_VARIANT_VERSION && $SUSE_VARIANT_VERSION -lt 20210722 ]]; then
   mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
   cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
 [Service]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:
Improves the version constraint for the mitigation from #50.
This is needed because newer SP2 versions are still using systemd 234.X but the mitigation is not needed for them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have tested this change with
- 15.2.20210610: The latest version needs the mitigation and the extension applies it.
- 15.2.20210722: The first SP2 version that has upstream fix and the extension does not need to apply the mitigation.
- 15.3.20210629: SP3 was never affected.

And the mitigation was applied only to `15.2.20210610` as it is expected.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A mitigation for issue with `systemd-hostnamed`, see (here)[https://github.com/gardener/gardener-extension-os-suse-chost/pull/50] for more details, is now applied only to older SuSE versions that does not contain an upstream fix in the `systemd` package.
```
