### PR TITLE
Enable and restart all units of `OSC` with purpose `provision`

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -149,9 +149,8 @@ systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
 systemctl enable docker && systemctl restart docker
-systemctl enable gardener-node-init && systemctl restart gardener-node-init
 
-#Set journald storage to persistent such that logs are written to /var/log instead of /run/log
+# Set journald storage to persistent such that logs are written to /var/log instead of /run/log
 if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; then
   mkdir -p /etc/systemd/journald.conf.d
   cat <<EOF > /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf
@@ -159,7 +158,14 @@ if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; t
 Storage=persistent
 EOF
   systemctl restart systemd-journald
-fi`
+fi
+
+`
+
+	for _, unit := range osc.Spec.Units {
+		script += fmt.Sprintf(`systemctl enable '%s' && systemctl restart --no-block '%s'
+`, unit.Name, unit.Name)
+	}
 
 	if osc.Spec.Type == memoryone.OSTypeMemoryOneCHost {
 		return wrapIntoMemoryOneHeaderAndFooter(osc, script)

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -156,9 +156,8 @@ systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
 systemctl enable docker && systemctl restart docker
-systemctl enable gardener-node-init && systemctl restart gardener-node-init
 
-#Set journald storage to persistent such that logs are written to /var/log instead of /run/log
+# Set journald storage to persistent such that logs are written to /var/log instead of /run/log
 if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; then
   mkdir -p /etc/systemd/journald.conf.d
   cat <<EOF > /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf
@@ -166,7 +165,10 @@ if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; t
 Storage=persistent
 EOF
   systemctl restart systemd-journald
-fi`
+fi
+
+systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+`
 
 			When("OS type is 'suse-chost'", func() {
 				Describe("#Reconcile", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:
This PR enables and restarts all systemd unit provided by `OperatingSystemConfig` with purpose `provision` when `gardener-node-agent` is enabled.
Currently, `gardener-node-agent` is the only unit, but https://github.com/gardener/gardener/pull/9077 introduces `gardener-user` and `sshd-ensurer` which need to be started to work properly.
Additional units might follow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
