### PR TITLE
Remove hardcoded MTU host network setting for eth0

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -97,12 +97,6 @@ EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
-if [[ -d /sys/class/net/eth0 ]]
-then
-  ip link set dev eth0 mtu 1460
-  grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
-  wicked ifreload eth0
-fi
 
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -92,12 +92,6 @@ EOF
 cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
 Zm9v
 EOF
-if [[ -d /sys/class/net/eth0 ]]
-then
-  ip link set dev eth0 mtu 1460
-  grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
-  wicked ifreload eth0
-fi
 
 # mitigate https://github.com/systemd/systemd/issues/7082
 # ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/area networking
/kind cleanup
/os suse-chost

**What this PR does / why we need it**:
Removes hardcoded MTU host network setting for eth0. This enables infrastructure providers to use their default MTU settings. 

**Which issue(s) this PR fixes**:
Fixes #179 

**Special notes for your reviewer**:
This is my first PR. Please let me know what I can improve. 🙏

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove hardcoded MTU host network setting for eth0.
```
