### PR TITLE
use buildx to build docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
 LD_FLAGS                    := "-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
 LEADER_ELECTION             := true
 IGNORE_OPERATION_ANNOTATION := true
+PLATFORM                    ?= linux/amd64
 
 #########################################
 # Tools                                 #
@@ -50,8 +51,13 @@ docker-login:
 
 .PHONY: docker-images
 docker-images:
-	@docker build -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
-
+	@docker buildx build --platform=$(PLATFORM) \
+		-t $(IMAGE_PREFIX)/$(NAME):$(VERSION) \
+		-t $(IMAGE_PREFIX)/$(NAME):latest \
+		-f Dockerfile \
+		-m 6g \
+		--target $(EXTENSION_PREFIX)-$(NAME) \
+		.
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #
 #####################################################################


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind technical-debt
/os suse-chost

**What this PR does / why we need it**:

Changes the Makefile to use docker buildx to build container images for this extensions so that we can build images for multiple architectures with linux/amd64 being the default.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Container images for the suse-chost extension are now built with Docker buildx to enable cross-platform builds and default to the `linux/amd64` architecture.
```
