### PR TITLE
Deploy sysctls to accept IPv6 router advertisements

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -185,7 +185,7 @@ func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfi
 			Permissions: ptr.To(uint32(0644)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
-					Data: `# enables IPv6 router advertisements on all interfaces even when ip_forward is enabled
+					Data: `# enables IPv6 router advertisements on all interfaces even when ip forwarding for IPv6 is enabled
 net.ipv6.conf.all.accept_ra = 2
 
 # specifically enable IPv6 router advertisements on the first ethernet interface (eth0 for net.ifnames=0)

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -175,6 +176,25 @@ Content-Type: text/x-shellscript
 }
 
 func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	// os-suse-chost does not add any additional units or additional files
-	return nil, nil, nil
+
+	// enable accepting IPv6 router advertisements so that the interface can obtain a default route
+	// when IP forwarding is enabled (which it is in K8S context)
+	files := []extensionsv1alpha1.File{
+		{
+			Path:        "/etc/sysctl.d/98-enable-ipv6-ra.conf",
+			Permissions: ptr.To(uint32(0644)),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Data: `# enables IPv6 router advertisements on all interfaces even when ip_forward is enabled
+net.ipv6.conf.all.accept_ra = 2
+
+# specifically enable IPv6 router advertisements on the first ethernet interface (eth0 for net.ifnames=0)
+net.ipv6.conf.eth0.accept_ra = 2
+`,
+				},
+			},
+		},
+	}
+
+	return nil, files, nil
 }

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -212,7 +212,7 @@ Content-Type: text/x-shellscript
 				_, _, extensionFiles, err := actuator.Reconcile(ctx, log, osc)
 				Expect(err).NotTo(HaveOccurred())
 
-				sysctl_content := `# enables IPv6 router advertisements on all interfaces even when ip_forward is enabled
+				sysctl_content := `# enables IPv6 router advertisements on all interfaces even when ip forwarding for IPv6 is enabled
 net.ipv6.conf.all.accept_ra = 2
 
 # specifically enable IPv6 router advertisements on the first ethernet interface (eth0 for net.ifnames=0)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:

Deploys a sysctl file to `/etc/sysctl.d` to enable accepting IPv6 router advertisements even when ip forwarding is enabled.

**Which issue(s) this PR fixes**:
Fixes #203

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Nodes running SuSE cHost are configured to accept IPv6 router advertisements even if they have IP forwarding enabled.
```
