### PR TITLE
Remove Docker from provisioning OSC

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -68,24 +68,11 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	writeUnitsToDiskScript := operatingsystemconfig.UnitsToDiskScript(osc.Spec.Units)
 
 	script := `#!/bin/bash
-# disable the default log rotation
-mkdir -p /etc/docker/
-cat <<EOF > /etc/docker/daemon.json
-{
-  "log-level": "warn",
-  "log-driver": "json-file"
-}
-EOF
-
 CONTAINERD_CONFIG_PATH=/etc/containerd/config.toml
 if [[ ! -s "${CONTAINERD_CONFIG_PATH}" || $(cat ${CONTAINERD_CONFIG_PATH}) == "# See containerd-config.toml(5) for documentation." ]]; then
   mkdir -p /etc/containerd
   containerd config default > "${CONTAINERD_CONFIG_PATH}"
   chmod 0644 "${CONTAINERD_CONFIG_PATH}"
-fi
-
-if systemctl show containerd -p Conflicts | grep -q docker; then
-  sed -re 's/Conflicts=(.*)(docker.service|docker)(.*)/Conflicts=\1 \3/g' -i /usr/lib/systemd/system/containerd.service
 fi
 
 mkdir -p /etc/systemd/system/containerd.service.d
@@ -113,14 +100,12 @@ EOF
   systemctl daemon-reload
 fi
 
-until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
-ln -s /usr/bin/docker /bin/docker
+until zypper -q install -y wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
 
 # Set journald storage to persistent such that logs are written to /var/log instead of /run/log
 if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; then

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -54,24 +54,11 @@ var _ = Describe("Actuator", func() {
 
 	When("purpose is 'provision'", func() {
 		expectedUserData := `#!/bin/bash
-# disable the default log rotation
-mkdir -p /etc/docker/
-cat <<EOF > /etc/docker/daemon.json
-{
-  "log-level": "warn",
-  "log-driver": "json-file"
-}
-EOF
-
 CONTAINERD_CONFIG_PATH=/etc/containerd/config.toml
 if [[ ! -s "${CONTAINERD_CONFIG_PATH}" || $(cat ${CONTAINERD_CONFIG_PATH}) == "# See containerd-config.toml(5) for documentation." ]]; then
   mkdir -p /etc/containerd
   containerd config default > "${CONTAINERD_CONFIG_PATH}"
   chmod 0644 "${CONTAINERD_CONFIG_PATH}"
-fi
-
-if systemctl show containerd -p Conflicts | grep -q docker; then
-  sed -re 's/Conflicts=(.*)(docker.service|docker)(.*)/Conflicts=\1 \3/g' -i /usr/lib/systemd/system/containerd.service
 fi
 
 mkdir -p /etc/systemd/system/containerd.service.d
@@ -108,14 +95,12 @@ EOF
   systemctl daemon-reload
 fi
 
-until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
-ln -s /usr/bin/docker /bin/docker
+until zypper -q install -y wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
 
 # Set journald storage to persistent such that logs are written to /var/log instead of /run/log
 if [[ ! -f /etc/systemd/journald.conf.d/10-use-persistent-log-storage.conf ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind technical-debt
/os suse-chost

**What this PR does / why we need it**:

As Kubernetes in general and Gardener in particular no longer support docker as container runtime (and no longer require it for unpacking OCI images), it is no longer necessary to install docker with zypper during node bootstrap.

**Which issue(s) this PR fixes**:
Fixes #194

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The suse-chost OS extension no longer installs docker with zypper during bootstrap of a cHost node. 
```
