### PR TITLE
Ensure that the provision OSC script runs only once

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -69,6 +69,7 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	writeUnitsToDiskScript := operatingsystemconfig.UnitsToDiskScript(osc.Spec.Units)
 
 	script := `#!/bin/bash
+
 # disable the default log rotation
 mkdir -p /etc/docker/
 cat <<EOF > /etc/docker/daemon.json
@@ -139,6 +140,9 @@ fi
 		script += fmt.Sprintf(`systemctl enable '%s' && systemctl restart --no-block '%s'
 `, unit.Name, unit.Name)
 	}
+
+	// The provisioning script must run only once.
+	script = operatingsystemconfig.WrapProvisionOSCIntoOneshotScript(script)
 
 	if osc.Spec.Type == memoryone.OSTypeMemoryOneCHost {
 		return wrapIntoMemoryOneHeaderAndFooter(osc, script)

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -54,6 +54,12 @@ var _ = Describe("Actuator", func() {
 
 	When("purpose is 'provision'", func() {
 		expectedUserData := `#!/bin/bash
+if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+  echo "Provision OSC already applied, exiting..."
+  exit 0
+fi
+
+
 # disable the default log rotation
 mkdir -p /etc/docker/
 cat <<EOF > /etc/docker/daemon.json
@@ -128,6 +134,10 @@ EOF
 fi
 
 systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+
+
+mkdir -p /var/lib/osc
+touch /var/lib/osc/provision-osc-applied
 `
 
 		When("OS type is 'suse-chost'", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug
/os suse-chost

**What this PR does / why we need it**:
At the moment the provision OSC script can run multiple times e.g. every time the node VM is rebooting.
This might tamper the configuration of gardener-node-agent and other components deployed by Gardener to the node machine.
Thus, this PR wraps the script with a function which makes it exit early if it already ran before. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11194

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The provision OSC script does not run anymore when the node is rebooting. 
```
