### PR TITLE
Disable the `docker` systemd service

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -76,6 +76,9 @@ if [[ ! -s "${CONTAINERD_CONFIG_PATH}" || $(cat ${CONTAINERD_CONFIG_PATH}) == "#
   chmod 0644 "${CONTAINERD_CONFIG_PATH}"
 fi
 
+# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
+# In case of reboot, the docker unit is started and prevents the containerd unit from starting.
+# Due to this reason, update the containerd unit to do not conflict with the docker unit.
 if systemctl show containerd -p Conflicts | grep -q docker; then
   cp /usr/lib/systemd/system/containerd.service /etc/systemd/system/containerd.service
   sed -re 's/Conflicts=(.*)(docker.service|docker)(.*)/Conflicts=\1 \3/g' -i /etc/systemd/system/containerd.service
@@ -112,6 +115,9 @@ if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
+
+# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
+# Disable the docker unit to prevent a reboot from starting it.
 systemctl disable docker && systemctl stop docker || echo "No docker service to disable or stop"
 
 # Set journald storage to persistent such that logs are written to /var/log instead of /run/log

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -66,6 +66,9 @@ if [[ ! -s "${CONTAINERD_CONFIG_PATH}" || $(cat ${CONTAINERD_CONFIG_PATH}) == "#
   chmod 0644 "${CONTAINERD_CONFIG_PATH}"
 fi
 
+# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
+# In case of reboot, the docker unit is started and prevents the containerd unit from starting.
+# Due to this reason, update the containerd unit to do not conflict with the docker unit.
 if systemctl show containerd -p Conflicts | grep -q docker; then
   cp /usr/lib/systemd/system/containerd.service /etc/systemd/system/containerd.service
   sed -re 's/Conflicts=(.*)(docker.service|docker)(.*)/Conflicts=\1 \3/g' -i /etc/systemd/system/containerd.service
@@ -111,6 +114,9 @@ if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
 systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
+
+# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
+# Disable the docker unit to prevent a reboot from starting it.
 systemctl disable docker && systemctl stop docker || echo "No docker service to disable or stop"
 
 # Set journald storage to persistent such that logs are written to /var/log instead of /run/log


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug
/os suse-chost

**What this PR does / why we need it**:
PR disables and stops the `docker` service.
PR also allows `containerd` service to start even if the `docker` service is running.
Having `docker` service running is a security risk for us - we neither require or utilize it. Service should be disable to reduce that attack vector.

**Which issue(s) this PR fixes**:
Fixes a regression introduced within #205

**Special notes for your reviewer**:
/invite @ialidzhikov 
In addition to removing the `containerd` conflict I've set the unit file to the system specific location. For that I've added a copy step, as `Conflict` directive is additive.
I've decided against modifying the vendor provided unit file, following [this page](https://www.freedesktop.org/software/systemd/man/latest/file-hierarchy.html).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing a suse-chost Node to be unhealthy (afterwards replaced) after a reboot due to the containerd unit conflict with the predefined docker unit in the OS image is now fixed.
```
