### PR TITLE
Add generation for `Extension` example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT)
 	@REPO_ROOT=$(REPO_ROOT) bash $(GARDENER_HACK_DIR)/check-charts.sh ./charts
 
 .PHONY: generate
-generate: $(VGOPATH) $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(MOCKGEN) $(YQ)
-	@REPO_ROOT=$(REPO_ROOT) VGOPATH=$(VGOPATH) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(GARDENER_HACK_DIR)/generate-sequential.sh ./charts/... ./cmd/... ./pkg/...
+generate: $(VGOPATH) $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(KUSTOMIZE) $(MOCKGEN) $(YQ)
+	@REPO_ROOT=$(REPO_ROOT) VGOPATH=$(VGOPATH) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(GARDENER_HACK_DIR)/generate-sequential.sh ./charts/... ./cmd/... ./example/... ./pkg/...
 	$(MAKE) format
 
 .PHONY: sast

--- a/example/doc.go
+++ b/example/doc.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:generate sh -c "$TOOLS_BIN_DIR/extension-generator --name=os-suse-chost --provider-type=suse-chost --component-category=operating-system --extension-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/os-suse-chost:$(cat ../VERSION) --destination=./extension/base/extension.yaml"
+//go:generate sh -c "$TOOLS_BIN_DIR/kustomize build ./extension -o ./extension.yaml"
+
+package example

--- a/example/extension.yaml
+++ b/example/extension.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: os-suse-chost
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/os-suse-chost:v1.31.0-dev
+  resources:
+  - kind: OperatingSystemConfig
+    type: suse-chost
+  - kind: OperatingSystemConfig
+    type: memoryone-chost

--- a/example/extension/base/extension.yaml
+++ b/example/extension/base/extension.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: os-suse-chost
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/os-suse-chost:v1.31.0-dev
+  resources:
+  - kind: OperatingSystemConfig
+    type: suse-chost

--- a/example/extension/base/kustomization.yaml
+++ b/example/extension/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- extension.yaml

--- a/example/extension/extension.yaml
+++ b/example/extension/extension.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: os-suse-chost
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+spec:
+  resources:
+  - kind: OperatingSystemConfig
+    type: suse-chost
+  - kind: OperatingSystemConfig
+    type: memoryone-chost

--- a/example/extension/kustomization.yaml
+++ b/example/extension/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base
+
+patches:
+- path: extension.yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os ops-productivity
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:
This PR adds the generation for an `Extension` example manifest, similar to `[example/controller-registration.yaml](https://github.com/gardener/gardener-extension-os-suse-chost/blob/master/example/controller-registration.yaml)` which will be replaced on the long run.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An example `Extension` manifest for extension registration has been added. It can be found at `[example/extension.yaml](https://github.com/gardener/gardener-extension-os-suse-chost/blob/master/example/extension.yaml)`
```
