### PR TITLE
ci: fix permission for pull_request_target in conjunction with trusted label

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
       version-commit-callback-action-path: .github/actions/prepare-release
     permissions:
       contents: read
+      pull-requests: write
 
   oci-images:
     name: Build OCI-Images


### PR DESCRIPTION
**What this PR does / why we need it**:

If using pull_request_target in conjunction with trusted-label, `trusted-checkout`-action attempts to remove `trusted`-label. In order to do so, `pull-requests: write`-permission is needed.


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Issue resolved in other gardener repo here: https://github.com/gardener/dashboard/pull/2555/commits/1c8977dda50e5ef0334cb8412a9c9018da36f241

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
