### PR TITLE
Do not attempt to remove trusted labels in verify step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,8 @@ jobs:
         with:
           go-version: '1.24'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false
       - name: run-verify
         run: |
           set -eu


### PR DESCRIPTION
**What this PR does / why we need it**:
verify step does not need to remove labels. Currently it misses permissions to do so thats why PR checks in verify step are failing.

See [docs](https://github.com/gardener/cc-utils/blob/638a06aa7269ff36d8e616b300ef1f9a8a574d31/.github/actions/trusted-checkout/action.yaml#L41)

earlier run with `remove-trusted-label: true` is via prepare workflow ([see](https://github.com/gardener/cc-utils/blob/638a06aa7269ff36d8e616b300ef1f9a8a574d31/.github/workflows/prepare.yaml#L193)) in prepare step 

**Which issue(s) this PR fixes**:

Fixes workflow checks for forked PRs ([example](https://github.com/gardener/gardener-extension-os-suse-chost/actions/runs/17430932072/job/49488932304?pr=265#step:3:350)) 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
