### PR TITLE
Cleanup of OSC provision script

### DIFF
--- a/docs/systemd-units.md
+++ b/docs/systemd-units.md
@@ -1,0 +1,10 @@
+# Handling of systemd units
+
+During node bootstrap, the provision script performs some changes to existing systemd units which are listed here.
+
+## Docker
+
+Some versions of SuSE CHost come with a predefined docker unit - enabled but not started. In case of a reboot, the docker unit is started and prevents the containerd unit from starting.
+Due to this reason, in the provision script, we update the containerd unit to do not conflict with the docker unit.
+
+In addition, we are disabling the docker unit to prevent a reboot from starting it.

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -66,9 +66,7 @@ if [[ ! -s "${CONTAINERD_CONFIG_PATH}" || $(cat ${CONTAINERD_CONFIG_PATH}) == "#
   chmod 0644 "${CONTAINERD_CONFIG_PATH}"
 fi
 
-# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
-# In case of reboot, the docker unit is started and prevents the containerd unit from starting.
-# Due to this reason, update the containerd unit to do not conflict with the docker unit.
+# refer to https://github.com/gardener/gardener-extension-os-suse-chost/tree/master/docs/systemd-units.md
 if systemctl show containerd -p Conflicts | grep -q docker; then
   cp /usr/lib/systemd/system/containerd.service /etc/systemd/system/containerd.service
   sed -re 's/Conflicts=(.*)(docker.service|docker)(.*)/Conflicts=\1 \3/g' -i /etc/systemd/system/containerd.service
@@ -93,21 +91,6 @@ cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
 Zm9v
 EOF
 
-# mitigate https://github.com/systemd/systemd/issues/7082
-# ref https://github.com/coreos/bugs/issues/2193#issuecomment-337767555
-SYSTEMD_VERSION=$(rpm -q --qf %{VERSION} systemd | grep -Po '^[1-9]\d*')
-SUSE_VARIANT_VERSION=$(grep -oP '(?<=^VARIANT_VERSION=).+' /etc/os-release | tr -d '"')
-SUSE_SP_ID=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d '.' -f 2)
-
-if [[ $SYSMTED_VERSION -lt 236 && -n $SUSE_SP_ID && $SUSE_SP_ID -lt 3 && -n $SUSE_VARIANT_VERSION && $SUSE_VARIANT_VERSION -lt 20210722 ]]; then
-  mkdir -p /etc/systemd/system/systemd-hostnamed.service.d/
-  cat <<EOF > /etc/systemd/system/systemd-hostnamed.service.d/10-protect-system.conf
-[Service]
-ProtectSystem=full
-EOF
-  systemctl daemon-reload
-fi
-
 until zypper -q install -y wget socat jq nfs-client; [ $? -ne 7 ]; do sleep 1; done
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi
@@ -115,8 +98,6 @@ systemctl daemon-reload
 ln -s /usr/sbin/containerd-ctr /usr/sbin/ctr
 systemctl enable containerd && systemctl restart containerd
 
-# Some versions of SuSE CHost comes with a predefined docker unit - enabled but not started.
-# Disable the docker unit to prevent a reboot from starting it.
 systemctl disable docker && systemctl stop docker || echo "No docker service to disable or stop"
 
 # Set journald storage to persistent such that logs are written to /var/log instead of /run/log


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/os suse-chost

**What this PR does / why we need it**:

As the OSC provision produced by the SUSE cHost extension can become quite large (especially in a provider-extensions setup with several registry cache entries), we are scratching the 16kB size limit for user-data on AWS.

To remedy, this PR:

- removes multiline comments from the OSC provision script and places them into a dedicated file in `docs`.
- removes obsolete code to mitigate a bug in an ancient systemd version that was shipped in an equally ancient SUSE cHost version

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
To reduce the size of the user-data that needs to be transmitted to cloud-providers, some code that we can now consider obsolete was removed from the OSC provision script.
```
