### PR TITLE
new API type for configuring vSMP MemoryOne

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make install
 
 ############# gardener-extension-os-suse-chost
-FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-os-suse-chost
+FROM gcr.io/distroless/static-debian12:nonroot AS gardener-extension-os-suse-chost
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-os-suse-chost /gardener-extension-os-suse-chost

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ install:
 docker-login:
 	@gcloud auth activate-service-account --key-file .kube-secrets/gcr/gcr-readwrite.json
 
-.PHONY: docker-images
-docker-images:
+.PHONY: docker-image-extension
+docker-image-extension:
 	@docker buildx build --platform=$(PLATFORM) \
 		-t $(IMAGE_PREFIX)/$(NAME):$(VERSION) \
 		-t $(IMAGE_PREFIX)/$(NAME):latest \
@@ -58,6 +58,10 @@ docker-images:
 		-m 6g \
 		--target $(EXTENSION_PREFIX)-$(NAME) \
 		.
+
+.PHONY: docker-images
+docker-images: docker-image-extension
+
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #
 #####################################################################

--- a/hack/api-reference/memoryonechost.md
+++ b/hack/api-reference/memoryonechost.md
@@ -66,6 +66,18 @@ string
 <p>SystemMemory allows to configure the <code>system_memory</code> parameter. If not present, it will default to <code>6x</code>.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>vsmpConfiguration</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VsmpConfiguration allows to configure any setting of vSMP</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>

--- a/pkg/apis/memoryonechost/types.go
+++ b/pkg/apis/memoryonechost/types.go
@@ -18,4 +18,6 @@ type OperatingSystemConfiguration struct {
 	MemoryTopology *string
 	// SystemMemory allows to configure the `system_memory` parameter. If not present, it will default to `6x`.
 	SystemMemory *string
+	// VsmpConfiguration allows to configure any setting of vSMP
+	VsmpConfiguration map[string]string
 }

--- a/pkg/apis/memoryonechost/v1alpha1/types.go
+++ b/pkg/apis/memoryonechost/v1alpha1/types.go
@@ -21,4 +21,7 @@ type OperatingSystemConfiguration struct {
 	// SystemMemory allows to configure the `system_memory` parameter. If not present, it will default to `6x`.
 	// +optional
 	SystemMemory *string `json:"systemMemory,omitempty"`
+	// VsmpConfiguration allows to configure any setting of vSMP
+	// +optional
+	VsmpConfiguration map[string]string `json:"vsmpConfiguration,omitempty"`
 }

--- a/pkg/apis/memoryonechost/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/memoryonechost/v1alpha1/zz_generated.conversion.go
@@ -40,6 +40,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_OperatingSystemConfiguration_To_memoryonechost_OperatingSystemConfiguration(in *OperatingSystemConfiguration, out *memoryonechost.OperatingSystemConfiguration, s conversion.Scope) error {
 	out.MemoryTopology = (*string)(unsafe.Pointer(in.MemoryTopology))
 	out.SystemMemory = (*string)(unsafe.Pointer(in.SystemMemory))
+	out.VsmpConfiguration = *(*map[string]string)(unsafe.Pointer(&in.VsmpConfiguration))
 	return nil
 }
 
@@ -51,6 +52,7 @@ func Convert_v1alpha1_OperatingSystemConfiguration_To_memoryonechost_OperatingSy
 func autoConvert_memoryonechost_OperatingSystemConfiguration_To_v1alpha1_OperatingSystemConfiguration(in *memoryonechost.OperatingSystemConfiguration, out *OperatingSystemConfiguration, s conversion.Scope) error {
 	out.MemoryTopology = (*string)(unsafe.Pointer(in.MemoryTopology))
 	out.SystemMemory = (*string)(unsafe.Pointer(in.SystemMemory))
+	out.VsmpConfiguration = *(*map[string]string)(unsafe.Pointer(&in.VsmpConfiguration))
 	return nil
 }
 

--- a/pkg/apis/memoryonechost/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/memoryonechost/v1alpha1/zz_generated.deepcopy.go
@@ -27,6 +27,13 @@ func (in *OperatingSystemConfiguration) DeepCopyInto(out *OperatingSystemConfigu
 		*out = new(string)
 		**out = **in
 	}
+	if in.VsmpConfiguration != nil {
+		in, out := &in.VsmpConfiguration, &out.VsmpConfiguration
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/memoryonechost/zz_generated.deepcopy.go
+++ b/pkg/apis/memoryonechost/zz_generated.deepcopy.go
@@ -27,6 +27,13 @@ func (in *OperatingSystemConfiguration) DeepCopyInto(out *OperatingSystemConfigu
 		*out = new(string)
 		**out = **in
 	}
+	if in.VsmpConfiguration != nil {
+		in, out := &in.VsmpConfiguration, &out.VsmpConfiguration
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -128,34 +128,6 @@ fi
 	return script, nil
 }
 
-func wrapIntoMemoryOneHeaderAndFooter(osc *extensionsv1alpha1.OperatingSystemConfig, in string) (string, error) {
-	config, err := memoryone.Configuration(osc)
-	if err != nil {
-		return "", err
-	}
-
-	memoryTopology, systemMemory := "2", "6x"
-	if config != nil && config.MemoryTopology != nil {
-		memoryTopology = *config.MemoryTopology
-	}
-	if config != nil && config.SystemMemory != nil {
-		systemMemory = *config.SystemMemory
-	}
-
-	out := `Content-Type: multipart/mixed; boundary="==BOUNDARY=="
-MIME-Version: 1.0
---==BOUNDARY==
-Content-Type: text/x-vsmp; section=vsmp
-system_memory=` + systemMemory + `
-mem_topology=` + memoryTopology + `
---==BOUNDARY==
-Content-Type: text/x-shellscript
-` + in + `
---==BOUNDARY==`
-
-	return out, nil
-}
-
 func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 
 	// enable accepting IPv6 router advertisements so that the interface can obtain a default route

--- a/pkg/controller/operatingsystemconfig/memoryone.go
+++ b/pkg/controller/operatingsystemconfig/memoryone.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig
+
+import (
+	"fmt"
+	"strings"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	memoryonechost "github.com/gardener/gardener-extension-os-suse-chost/pkg/apis/memoryonechost/v1alpha1"
+	"github.com/gardener/gardener-extension-os-suse-chost/pkg/memoryone"
+)
+
+const (
+	memoryTopology = "mem_topology"
+	systemMemory   = "system_memory"
+)
+
+func wrapIntoMemoryOneHeaderAndFooter(osc *extensionsv1alpha1.OperatingSystemConfig, in string) (string, error) {
+	config, err := memoryone.Configuration(osc)
+	if err != nil {
+		return "", err
+	}
+
+	memoryOneConfiguration := vsmpConfigString(config)
+
+	out := `Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+--==BOUNDARY==
+Content-Type: text/x-vsmp; section=vsmp
+
+` + memoryOneConfiguration + `
+--==BOUNDARY==
+Content-Type: text/x-shellscript
+
+` + in + `
+--==BOUNDARY==--
+`
+
+	return out, nil
+}
+
+func vsmpConfigString(config *memoryonechost.OperatingSystemConfiguration) string {
+	var vsmpConfiguration map[string]string
+	var configStringBuilder strings.Builder
+
+	if config != nil && config.VsmpConfiguration != nil {
+		vsmpConfiguration = config.VsmpConfiguration
+		// TODO: put stripSemicola down into the StringBuilder-Fprintf and remove this loop once we end support for legacy values
+		// this is required as we do not want to allow injecting key-value pairs with semicola in the new parameter map
+		// but need to retain the previous behaviour for the legacy configuration style
+		for k, v := range vsmpConfiguration {
+			vsmpConfiguration[k] = stripSemicola(v)
+		}
+	} else {
+		vsmpConfiguration = make(map[string]string, 2)
+	}
+
+	if _, ok := vsmpConfiguration[memoryTopology]; !ok {
+		vsmpConfiguration[memoryTopology] = "2"
+	}
+
+	if _, ok := vsmpConfiguration[systemMemory]; !ok {
+		vsmpConfiguration[systemMemory] = "6x"
+	}
+
+	// TODO: remove these once the transition to VsmpConfiguration map[string]string is complete
+	if config != nil {
+		if config.SystemMemory != nil {
+			vsmpConfiguration[systemMemory] = *config.SystemMemory
+		}
+
+		if config.MemoryTopology != nil {
+			vsmpConfiguration[memoryTopology] = *config.MemoryTopology
+		}
+	}
+	// end TODO
+
+	for k, v := range vsmpConfiguration {
+		fmt.Fprintf(&configStringBuilder, "%s=%s\n", stripSemicola(k), v)
+	}
+
+	return configStringBuilder.String()
+}
+
+func stripSemicola(s string) string {
+	before, _, found := strings.Cut(s, ";")
+	if found {
+		return before
+	}
+	return s
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/kind api-change
/os suse-chost

**What this PR does / why we need it**:

A new API type for passing configuration parameters to vSMP MemoryOne is introduced which allows any key-values combination to be passed in.

During development, problems with the construction of a RFC 2046 compliant multipart message were detected which got fixed.

**Which issue(s) this PR fixes**:
addresses issue #144 (but does not fix it yet)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The suse-chost OS extension now supports a new API type to pass in additional vSMP configuration options for ScaleMP MemoryOne so that these values no longer need to be injected through one of the `memoryTopology` or `systemMemory` fields.
```
