### PR TITLE
fix(osc): set kubelet --fail-cgroupv1=false for k8s [1.35, 1.38)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/gardener-extension-os-suse-chost
 go 1.25.7
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/elastic/crd-ref-docs v0.3.0
 	github.com/gardener/gardener v1.142.0
 	github.com/gardener/gardener/pkg/apis v1.142.0
@@ -24,7 +25,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/PaesslerAG/gval v1.2.4 // indirect
 	github.com/PaesslerAG/jsonpath v0.1.2-0.20240726212847-3a740cf7976f // indirect

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -26,6 +26,15 @@ import (
 // we explicitly set the flag to false from this version onwards so kubelet starts.
 var kubeletFailCgroupV1MinVersion = semver.MustParse("1.35.0")
 
+// kubeletFailCgroupV1RemovedVersion is the earliest Kubernetes version in which
+// cgroup v1 support (and therefore the --fail-cgroupv1 flag) may be removed from
+// kubelet. KEP-5573 states: "The removal will be done no earlier than 1.38 to
+// maintain the k8s deprecation policy."
+// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5573-remove-cgroup-v1
+// From this version on, passing the flag may cause kubelet to fail to start with
+// an unknown-flag error, so we must not emit it.
+var kubeletFailCgroupV1RemovedVersion = semver.MustParse("1.38.0")
+
 type actuator struct {
 	client client.Client
 }
@@ -167,9 +176,10 @@ net.ipv6.conf.eth0.accept_ra = 2
 }
 
 // kubeletFailCgroupV1File returns a file that sets KUBELET_EXTRA_ARGS=--fail-cgroupv1=false
-// when the shoot's Kubernetes version is >= 1.35. Starting with K8s 1.35, kubelet defaults
-// --fail-cgroupv1 to true and refuses to start on cgroup v1 hosts (KEP-5573). SUSE-CHost still
-// runs cgroup v1, so the kubelet would otherwise fail to start.
+// when the shoot's Kubernetes version is in [1.35, 1.38). Starting with K8s 1.35, kubelet
+// defaults --fail-cgroupv1 to true and refuses to start on cgroup v1 hosts (KEP-5573).
+// SUSE-CHost still runs cgroup v1, so the kubelet would otherwise fail to start.
+// The flag (and cgroup v1 support) are removed in K8s 1.38, so we must not pass it from then on.
 // The file is consumed by kubelet.service via `EnvironmentFile=-/var/lib/kubelet/extra_args`,
 // see github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go.
 func (a *actuator) kubeletFailCgroupV1File(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig) (*extensionsv1alpha1.File, error) {
@@ -185,7 +195,7 @@ func (a *actuator) kubeletFailCgroupV1File(ctx context.Context, osc *extensionsv
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kubernetes version %q: %w", cluster.Shoot.Spec.Kubernetes.Version, err)
 	}
-	if version.LessThan(kubeletFailCgroupV1MinVersion) {
+	if version.LessThan(kubeletFailCgroupV1MinVersion) || !version.LessThan(kubeletFailCgroupV1RemovedVersion) {
 		return nil, nil
 	}
 

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -9,8 +9,10 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,6 +20,11 @@ import (
 
 	"github.com/gardener/gardener-extension-os-suse-chost/pkg/memoryone"
 )
+
+// kubeletFailCgroupV1MinVersion is the first Kubernetes version that defaults
+// kubelet's --fail-cgroupv1 flag to true. Since SUSE-CHost still runs cgroup v1,
+// we explicitly set the flag to false from this version onwards so kubelet starts.
+var kubeletFailCgroupV1MinVersion = semver.MustParse("1.35.0")
 
 type actuator struct {
 	client client.Client
@@ -37,8 +44,8 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, osc *extensions
 		return []byte(userData), nil, nil, nil, err
 
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
-		extensionFiles := a.handleReconcileOSC(osc)
-		return nil, nil, extensionFiles, nil, nil
+		extensionFiles, err := a.handleReconcileOSC(ctx, osc)
+		return nil, nil, extensionFiles, nil, err
 
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unknown purpose: %s", purpose)
@@ -128,7 +135,7 @@ fi
 	return script, nil
 }
 
-func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfig) []extensionsv1alpha1.File {
+func (a *actuator) handleReconcileOSC(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.File, error) {
 	// enable accepting IPv6 router advertisements so that the interface can obtain a default route
 	// when IP forwarding is enabled (which it is in K8S context)
 	files := []extensionsv1alpha1.File{
@@ -148,5 +155,47 @@ net.ipv6.conf.eth0.accept_ra = 2
 		},
 	}
 
-	return files
+	failCgroupV1File, err := a.kubeletFailCgroupV1File(ctx, osc)
+	if err != nil {
+		return nil, err
+	}
+	if failCgroupV1File != nil {
+		files = append(files, *failCgroupV1File)
+	}
+
+	return files, nil
+}
+
+// kubeletFailCgroupV1File returns a file that sets KUBELET_EXTRA_ARGS=--fail-cgroupv1=false
+// when the shoot's Kubernetes version is >= 1.35. Starting with K8s 1.35, kubelet defaults
+// --fail-cgroupv1 to true and refuses to start on cgroup v1 hosts (KEP-5573). SUSE-CHost still
+// runs cgroup v1, so the kubelet would otherwise fail to start.
+// The file is consumed by kubelet.service via `EnvironmentFile=-/var/lib/kubelet/extra_args`,
+// see github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go.
+func (a *actuator) kubeletFailCgroupV1File(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig) (*extensionsv1alpha1.File, error) {
+	cluster, err := extensions.GetCluster(ctx, a.client, osc.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster: %w", err)
+	}
+	if cluster == nil || cluster.Shoot == nil {
+		return nil, nil
+	}
+
+	version, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubernetes version %q: %w", cluster.Shoot.Spec.Kubernetes.Version, err)
+	}
+	if version.LessThan(kubeletFailCgroupV1MinVersion) {
+		return nil, nil
+	}
+
+	return &extensionsv1alpha1.File{
+		Path:        "/var/lib/kubelet/extra_args",
+		Permissions: ptr.To(uint32(0644)),
+		Content: extensionsv1alpha1.FileContent{
+			Inline: &extensionsv1alpha1.FileContentInline{
+				Data: "KUBELET_EXTRA_ARGS=--fail-cgroupv1=false\n",
+			},
+		},
+	}, nil
 }

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -6,12 +6,14 @@ package operatingsystemconfig_test
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/go-logr/logr"
@@ -32,12 +34,19 @@ import (
 	"github.com/gardener/gardener-extension-os-suse-chost/pkg/susechost"
 )
 
-var codec runtime.Codec
+var (
+	codec      runtime.Codec
+	testScheme *runtime.Scheme
+)
 
 func init() {
 	scheme := runtime.NewScheme()
 	runtimeutils.Must(memoryonev1alpha1.AddToScheme(scheme))
 	codec = serializer.NewCodecFactory(scheme, serializer.EnableStrict).LegacyCodec(memoryonev1alpha1.SchemeGroupVersion)
+
+	testScheme = runtime.NewScheme()
+	runtimeutils.Must(extensionsv1alpha1.AddToScheme(testScheme))
+	runtimeutils.Must(gardencorev1beta1.AddToScheme(testScheme))
 }
 
 var _ = Describe("Actuator", func() {
@@ -52,11 +61,14 @@ var _ = Describe("Actuator", func() {
 	)
 
 	BeforeEach(func() {
-		fakeClient = fakeclient.NewClientBuilder().Build()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
 		mgr = test.FakeManager{Client: fakeClient}
 		actuator = NewActuator(mgr)
 
 		osc = &extensionsv1alpha1.OperatingSystemConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "shoot--foo--bar",
+			},
 			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 				DefaultSpec: extensionsv1alpha1.DefaultSpec{
 					Type: susechost.OSTypeSuSECHost,
@@ -337,29 +349,73 @@ touch /var/lib/osc/provision-osc-applied
 		})
 
 		Describe("#Reconcile", func() {
-			It("should not return an error", func() {
-				userData, extensionUnits, _, _, err := actuator.Reconcile(ctx, log, osc)
-				Expect(err).NotTo(HaveOccurred())
+			Context("when the shoot's Kubernetes version is < 1.35", func() {
+				BeforeEach(func() {
+					Expect(createCluster(ctx, fakeClient, osc.Namespace, "1.34.0")).To(Succeed())
+				})
 
-				Expect(userData).To(BeEmpty())
-				Expect(extensionUnits).To(BeEmpty())
-			})
+				It("should not return an error", func() {
+					userData, extensionUnits, _, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
 
-			It("should deploy a sysctl file to configure IPv6 router advertisements", func() {
-				_, _, extensionFiles, _, err := actuator.Reconcile(ctx, log, osc)
-				Expect(err).NotTo(HaveOccurred())
+					Expect(userData).To(BeEmpty())
+					Expect(extensionUnits).To(BeEmpty())
+				})
 
-				sysctl_content := `# enables IPv6 router advertisements on all interfaces even when ip forwarding for IPv6 is enabled
+				It("should deploy a sysctl file to configure IPv6 router advertisements", func() {
+					_, _, extensionFiles, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					sysctl_content := `# enables IPv6 router advertisements on all interfaces even when ip forwarding for IPv6 is enabled
 net.ipv6.conf.all.accept_ra = 2
 
 # specifically enable IPv6 router advertisements on the first ethernet interface (eth0 for net.ifnames=0)
 net.ipv6.conf.eth0.accept_ra = 2
 `
 
-				Expect(extensionFiles).To(HaveLen(1))
-				Expect(extensionFiles[0].Path).To(Equal("/etc/sysctl.d/98-enable-ipv6-ra.conf"))
-				Expect(extensionFiles[0].Permissions).To(Equal(ptr.To(uint32(0644))))
-				Expect(extensionFiles[0].Content.Inline.Data).To(Equal(sysctl_content))
+					Expect(extensionFiles).To(HaveLen(1))
+					Expect(extensionFiles[0].Path).To(Equal("/etc/sysctl.d/98-enable-ipv6-ra.conf"))
+					Expect(extensionFiles[0].Permissions).To(Equal(ptr.To(uint32(0644))))
+					Expect(extensionFiles[0].Content.Inline.Data).To(Equal(sysctl_content))
+				})
+
+				It("should not deploy the kubelet --fail-cgroupv1 extra_args file", func() {
+					_, _, extensionFiles, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, f := range extensionFiles {
+						Expect(f.Path).NotTo(Equal("/var/lib/kubelet/extra_args"))
+					}
+				})
+			})
+
+			Context("when the shoot's Kubernetes version is >= 1.35", func() {
+				BeforeEach(func() {
+					Expect(createCluster(ctx, fakeClient, osc.Namespace, "1.35.0")).To(Succeed())
+				})
+
+				It("should deploy the kubelet --fail-cgroupv1 extra_args file", func() {
+					_, _, extensionFiles, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					var extraArgs *extensionsv1alpha1.File
+					for i, f := range extensionFiles {
+						if f.Path == "/var/lib/kubelet/extra_args" {
+							extraArgs = &extensionFiles[i]
+							break
+						}
+					}
+					Expect(extraArgs).NotTo(BeNil())
+					Expect(extraArgs.Permissions).To(Equal(ptr.To(uint32(0644))))
+					Expect(extraArgs.Content.Inline.Data).To(Equal("KUBELET_EXTRA_ARGS=--fail-cgroupv1=false\n"))
+				})
+			})
+
+			Context("when the cluster resource cannot be found", func() {
+				It("should return an error", func() {
+					_, _, _, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 	})
@@ -454,4 +510,31 @@ func encodeMemoryOneConfigurationIntoOsc(codec runtime.Codec, osc *extensionsv1a
 		Raw: encoded,
 	}
 	return nil
+}
+
+func createCluster(ctx context.Context, c client.Client, name, kubernetesVersion string) error {
+	shoot := &gardencorev1beta1.Shoot{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+			Kind:       "Shoot",
+		},
+		Spec: gardencorev1beta1.ShootSpec{
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: kubernetesVersion,
+			},
+		},
+	}
+	shootRaw, err := json.Marshal(shoot)
+	if err != nil {
+		return err
+	}
+	cluster := &extensionsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: extensionsv1alpha1.ClusterSpec{
+			CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
+			Seed:         runtime.RawExtension{Raw: []byte("{}")},
+			Shoot:        runtime.RawExtension{Raw: shootRaw},
+		},
+	}
+	return c.Create(ctx, cluster)
 }

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -389,7 +389,7 @@ net.ipv6.conf.eth0.accept_ra = 2
 				})
 			})
 
-			Context("when the shoot's Kubernetes version is >= 1.35", func() {
+			Context("when the shoot's Kubernetes version is >= 1.35 and < 1.38", func() {
 				BeforeEach(func() {
 					Expect(createCluster(ctx, fakeClient, osc.Namespace, "1.35.0")).To(Succeed())
 				})

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -411,6 +411,21 @@ net.ipv6.conf.eth0.accept_ra = 2
 				})
 			})
 
+			Context("when the shoot's Kubernetes version is >= 1.38", func() {
+				BeforeEach(func() {
+					Expect(createCluster(ctx, fakeClient, osc.Namespace, "1.38.0")).To(Succeed())
+				})
+
+				It("should not deploy the kubelet --fail-cgroupv1 extra_args file", func() {
+					_, _, extensionFiles, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, f := range extensionFiles {
+						Expect(f.Path).NotTo(Equal("/var/lib/kubelet/extra_args"))
+					}
+				})
+			})
+
 			Context("when the cluster resource cannot be found", func() {
 				It("should return an error", func() {
 					_, _, _, _, err := actuator.Reconcile(ctx, log, osc)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement
/os suse-chost

**What this PR does / why we need it**:

K8s 1.35 flips kubelet's `--fail-cgroupv1` default to `true` (KEP-5573), which breaks kubelet on cgroup v1 hosts like SUSE-CHost. Per [KEP-5573](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5573-remove-cgroup-v1), "The removal will be done no earlier than 1.38 to maintain the k8s deprecation policy." — so from 1.38 on, the flag may be removed and passing it would cause kubelet to fail to start with an unknown-flag error.

The current latest released Kubernetes version is 1.36; 1.38 is not yet released. This PR writes `/var/lib/kubelet/extra_args` with `KUBELET_EXTRA_ARGS=--fail-cgroupv1=false` only when the shoot's Kubernetes version is in `[1.35, 1.38)`.

| K8s version | cgroup at boot | Behavior |
|---|---|---|
| `< 1.35` | v1 (SUSE-CHost) | no `extra_args` file; kubelet starts (default `--fail-cgroupv1=false`) |
| `[1.35, 1.38)` | v1 (SUSE-CHost) | writes `extra_args` with `--fail-cgroupv1=false`; kubelet starts |
| `>= 1.38` | v1 (SUSE-CHost) | no file emitted; flag may be removed in kubelet |

Note: an additional gate based on the SUSE-CHost OS image version (skip the file once the image defaults to cgroup v2) will be added in a follow-up once the first SUSE-CHost version with default cgroup v2 is known.

**Which issue(s) this PR fixes**:
Fixes #339

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
For shoots running Kubernetes `[1.35, 1.38)` on SUSE-CHost, kubelet is now started with `--fail-cgroupv1=false` so it works on cgroup v1 hosts. The flag is not set on K8s `>= 1.38`, where it may be removed per KEP-5573.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operating system configuration now includes Kubernetes release-specific behavior for versions 1.35 through 1.38, ensuring optimal compatibility and stability across diverse cluster configurations.

* **Tests**
  * Significantly expanded test coverage to validate version-specific configuration behavior, error scenarios, and edge cases across multiple Kubernetes releases.

* **Chores**
  * Updated project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/gardener-extension-os-suse-chost/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->